### PR TITLE
[v0.19] Remove Grayscale for Android Projects for Small Screens

### DIFF
--- a/css/homepage/homepage-styles-resp.css
+++ b/css/homepage/homepage-styles-resp.css
@@ -29,6 +29,11 @@
         width: 50%;
     }
 
+    .item-android-projects-thumb-grayscale {
+        filter: none;
+        -webkit-filter: grayscale(0%);
+    }
+
     .item-android-project-thumb-title {
         top: 14px;
     }
@@ -124,6 +129,11 @@
 
     .item-android-project-thumb-title {
         top: 28px;
+    }
+
+    .item-android-projects-thumb-grayscale {
+        filter: none;
+        -webkit-filter: grayscale(100%);
     }
 
     .resume-left-blue-box {


### PR DESCRIPTION
If you are viewing the website on a small screen, like an iPhone, remove the grayscale so that the android projects appear in color.